### PR TITLE
fix: falsy uniqueIdentifierFields causing an exception

### DIFF
--- a/src/lib/prisma-utils/whereUniqueInput.ts
+++ b/src/lib/prisma-utils/whereUniqueInput.ts
@@ -9,7 +9,7 @@ type FieldName = string
 export const createWhereUniqueInput = (source: RecordUnknown, model: DMMF.Model) => {
   // TODO There is no reason to compute this every time. Memoize or move.
   const uniqueIdentifierFields = getUniqueIdentifierFields(model)
-  const uniqueIdentifierFieldsMissingInData = uniqueIdentifierFields.filter((_) => !source[_])
+  const uniqueIdentifierFieldsMissingInData = uniqueIdentifierFields.filter((_) => source[_] == null)
 
   if (uniqueIdentifierFieldsMissingInData.length > 0) {
     // TODO rich errors


### PR DESCRIPTION
This pull request addresses a critical issue where uniqueIdentifierFields containing a falsy values cause an exception.

BTW: adding the following eslint rule would catch this kind of error: `@typescript-eslint/strict-boolean-expressions`

Also related, when the library throws an error it includes all fields returned by prisma, possibly including those which are not part of the graphql schema. Meaning that sensitive data can be leaked.