### PR TITLE
tests: update create schema function to add the prisma version to it.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,7 +68,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - name: Set E2E DB Schema
-        run: yarn -s ts-node scripts/get-e2e-db-schema --os ${{ matrix.os }} --node-version ${{ matrix.node-version }} --github-env $GITHUB_ENV
+        run: yarn -s ts-node scripts/get-e2e-db-schema --os ${{ matrix.os }} --node-version ${{ matrix.node-version }} --prisma-client-version ${{ matrix.prisma-client-version }} --github-env $GITHUB_ENV
       - run: yarn -s build
       - name: Install Prisma Client version
         run: yarn -s add @prisma/client@${{ matrix.prisma-client-version }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         node-version: [16.x]
-        prisma-client-version: ['3.5']
+        prisma-client-version: ['3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - name: Set E2E DB Schema
-        run: yarn -s ts-node scripts/get-e2e-db-schema --os ${{ matrix.os }} --node-version ${{ matrix.node-version }} --github-env $GITHUB_ENV
+        run: yarn -s ts-node scripts/get-e2e-db-schema --os ${{ matrix.os }} --node-version ${{ matrix.node-version }} --prisma-client-version ${{ matrix.prisma-client-version }} --github-env $GITHUB_ENV
       - run: yarn -s build
       - name: Install Prisma Client version
         run: yarn -s add @prisma/client@${{ matrix.prisma-client-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ generator.d.ts
 generator.js
 
 tests/__cache__
+
+.idea

--- a/scripts/get-e2e-db-schema.ts
+++ b/scripts/get-e2e-db-schema.ts
@@ -14,7 +14,7 @@ const nodeVersionParser = z.union([z.literal('14.x'), z.literal('16.x')])
 
 const osParser = z.union([z.literal('macos-latest'), z.literal('ubuntu-latest'), z.literal('windows-latest')])
 
-const prismaClientParser = z.string().regex(/\d+.\d+/)
+const prismaClientParser = z.string().regex(/3.\d+/)
 
 const connectionStringMapping: Record<ComboCase, string> = {
   '14.x + macos-latest': 'node_14_macos_latest',
@@ -51,13 +51,12 @@ if (args['--github-env']) {
 function parseComboCase(nodeVersionInput: string, osInput: string, prismaClientInput: string): string {
   const nodeVersion = nodeVersionParser.parse(nodeVersionInput)
   const os = osParser.parse(osInput)
-  // eslint-disable-next-line
-  const comboCase = [nodeVersion, os].join(' + ') as ComboCase
+  const comboCase: ComboCase = `${nodeVersion} + ${os}`
   const schema = connectionStringMapping[comboCase]
   if (!prismaClientInput) {
     return schema
   } else {
     const prismaClientVersion = prismaClientParser.parse(prismaClientInput)
-    return [schema,prismaClient].join('_') 
+    return [schema, prismaClientVersion].join('_')
   }
 }

--- a/scripts/get-e2e-db-schema.ts
+++ b/scripts/get-e2e-db-schema.ts
@@ -58,6 +58,6 @@ function parseComboCase(nodeVersionInput: string, osInput: string, prismaClientI
     return schema
   } else {
     const prismaClientVersion = prismaClientParser.parse(prismaClientInput)
-    return schema + prismaClient
+    return [schema,prismaClient].join('_') 
   }
 }

--- a/scripts/get-e2e-db-schema.ts
+++ b/scripts/get-e2e-db-schema.ts
@@ -14,6 +14,8 @@ const nodeVersionParser = z.union([z.literal('14.x'), z.literal('16.x')])
 
 const osParser = z.union([z.literal('macos-latest'), z.literal('ubuntu-latest'), z.literal('windows-latest')])
 
+const prismaClientParser = z.string().regex(/\d+.\d+/)
+
 const connectionStringMapping: Record<ComboCase, string> = {
   '14.x + macos-latest': 'node_14_macos_latest',
   '14.x + windows-latest': 'node_14_windows_latest',
@@ -26,24 +28,36 @@ const connectionStringMapping: Record<ComboCase, string> = {
 const args = arg({
   '--os': String,
   '--node-version': String,
+  '--prisma-client-version': String,
   '--github-env': String,
 })
 
-const comboCase = parseComboCase(args['--node-version'] ?? '', args['--os'] ?? '')
+const schemaName = parseComboCase(
+  args['--node-version'] ?? '',
+  args['--os'] ?? '',
+  args['--prisma-client-version'] ?? ''
+)
 
 if (args['--github-env']) {
-  fs.append(args['--github-env'], `E2E_DB_SCHEMA=${connectionStringMapping[comboCase]}`)
+  fs.append(args['--github-env'], `E2E_DB_SCHEMA=${schemaName}`)
 } else {
-  process.stdout.write(connectionStringMapping[comboCase])
+  process.stdout.write(schemaName)
 }
 
 //
 // Helpers
 //
 
-function parseComboCase(nodeVersionInput: string, osInput: string): ComboCase {
+function parseComboCase(nodeVersionInput: string, osInput: string, prismaClientInput: string): string {
   const nodeVersion = nodeVersionParser.parse(nodeVersionInput)
   const os = osParser.parse(osInput)
   // eslint-disable-next-line
-  return [nodeVersion, os].join(' + ') as any
+  const comboCase = [nodeVersion, os].join(' + ') as ComboCase
+  const schema = connectionStringMapping[comboCase]
+  if (!prismaClientInput) {
+    return schema
+  } else {
+    const prismaClient = prismaClientParser.parse(prismaClientInput)
+    return schema + prismaClient
+  }
 }

--- a/scripts/get-e2e-db-schema.ts
+++ b/scripts/get-e2e-db-schema.ts
@@ -57,7 +57,7 @@ function parseComboCase(nodeVersionInput: string, osInput: string, prismaClientI
   if (!prismaClientInput) {
     return schema
   } else {
-    const prismaClient = prismaClientParser.parse(prismaClientInput)
+    const prismaClientVersion = prismaClientParser.parse(prismaClientInput)
     return schema + prismaClient
   }
 }


### PR DESCRIPTION
Our test now does not support more than one past version test.
Because we have a DB from Heroku to test with and we use schema name for every test by os name and node version here you will use the same schema name so every test will reset the schema for the other one.

Updated the create schema function to add the prisma version to it.