### PR TITLE
Use the default @prisma/client package if the user using pnpm package

### DIFF
--- a/src/cli/nexus-prisma.ts
+++ b/src/cli/nexus-prisma.ts
@@ -135,6 +135,15 @@ function getPrismaClientImportIdForItsGeneratorOutputConfig(
     return prismaClientPackageMoniker
   }
 
+  /**
+   * when using a pnpm package manager it's generate a custom folder for every package and breaking our import.
+   * as a fix if we found that the prisma output path include the .pnpm folder we use the prismaClientPackageMoniker
+   */
+  const prismaClientOutputPNPM = Path.normalize(`/node_modules/.pnpm/@prisma+client`)
+  if (prismaClientGeneratorConfig.output.value.includes(prismaClientOutputPNPM)) {
+    return prismaClientPackageMoniker
+  }
+
   if (prismaClientGeneratorConfig.output.value.endsWith(prismaClientDefaultOutput)) {
     /**
      * Goal of this code:

--- a/src/cli/nexus-prisma.ts
+++ b/src/cli/nexus-prisma.ts
@@ -138,6 +138,7 @@ function getPrismaClientImportIdForItsGeneratorOutputConfig(
   /**
    * when using a pnpm package manager it's generate a custom folder for every package and breaking our import.
    * as a fix if we found that the prisma output path include the .pnpm folder we use the prismaClientPackageMoniker
+   * TODO: adding a test https://github.com/prisma/nexus-prisma/issues/189
    */
   const prismaClientOutputPNPM = Path.normalize(`/node_modules/.pnpm/@prisma+client`)
   if (prismaClientGeneratorConfig.output.value.includes(prismaClientOutputPNPM)) {

--- a/tests/e2e/kitchen-sink.test.ts
+++ b/tests/e2e/kitchen-sink.test.ts
@@ -88,7 +88,7 @@ beforeEach(() => {
       graphql: '^15.5.0',
       nexus: '1.1.0',
       prisma: '^3.5.0',
-      'ts-node': '^9.1.1',
+      'ts-node': '^10.8.1',
       'ts-node-dev': '^1.1.6',
       typescript: '^4.2.3',
     },


### PR DESCRIPTION
closes #189 

if the user using a `pnpm` package manager the output path for the generated Prisma client will be in a long path inside the `.pnpm` folder 

```
./node_modules/.pnpm/@prisma+client@3.12.0_prisma@3.12.0/node_modules/@prisma/client
```

it breaks the import of prisma client into our generator. the fix that we will check if the user using the default output and also using the `pnpm` package we will put the import from '@prisma/client' direct

```
 {
  dirPrismaClientOutputWithoutTrailingNodeModulesMoniker: '/Users/ahmedelywa/prisma/nexus-test/node_modules/.pnpm/@prisma+client@3.12.0_prisma@3.12.0',
  dirProjectForThisNexusPrisma: '/Users/ahmedelywa/prisma/nexus-test/node_modules/.pnpm/file+.yalc+nexus-prisma_mihg3e4rc7mnl6kgtp4j4yadxa',
  dirDiff: '../file+.yalc+nexus-prisma_mihg3e4rc7mnl6kgtp4j4yadxa'
}
```
