### PR TITLE
chore: add timeout for GitHub Actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   prettier:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -17,6 +18,7 @@ jobs:
 
   eslint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -27,6 +29,7 @@ jobs:
       - run: yarn -s lint:check
 
   test-latest-prisma:
+    timeout-minutes: 20
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
@@ -54,6 +57,7 @@ jobs:
           directory: ./coverage
 
   test-past-prisma:
+    timeout-minutes: 20
     strategy:
       matrix:
         os: ['ubuntu-latest']

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -5,6 +5,7 @@ on: workflow_dispatch
 jobs:
   bump-version:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   test-latest-prisma:
+    timeout-minutes: 20
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
@@ -33,6 +34,7 @@ jobs:
           directory: ./coverage
 
   test-past-prisma:
+    timeout-minutes: 20
     strategy:
       matrix:
         os: ['ubuntu-latest']
@@ -54,6 +56,7 @@ jobs:
       - run: yarn -s test:ci
 
   release-canary:
+    timeout-minutes: 20
     needs:
       - test-latest-prisma
       - test-past-prisma

--- a/tests/e2e/kitchen-sink.test.ts
+++ b/tests/e2e/kitchen-sink.test.ts
@@ -88,7 +88,7 @@ beforeEach(() => {
       graphql: '^15.5.0',
       nexus: '1.1.0',
       prisma: '^3.5.0',
-      'ts-node': '^9.1.1',
+      'ts-node': '^10.8.1',
       'ts-node-dev': '^1.1.6',
       typescript: '^4.2.3',
     },


### PR DESCRIPTION
@andrewicarlson the timeout will help avoid a +5h macos runner (which are a scarce resource) like in https://github.com/prisma/nexus-prisma/runs/6783174202?check_suite_focus=true :grimacing:

Feel free to edit the timeouts if needed