### PR TITLE
fix: remove colors from the the result to fix the local test

### DIFF
--- a/tests/checks/PrismaClientOnContext.test.ts
+++ b/tests/checks/PrismaClientOnContext.test.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag'
 import { objectType, queryType } from 'nexus'
 import { testIntegration, TestIntegrationParams, testIntegrationPartial } from '../__helpers__/testers'
+import { ansiEscapeSequencePattern } from '../../utils/ansiEscapeSequencePattern'
 
 const base = testIntegrationPartial({
   database: `
@@ -96,7 +97,10 @@ describe('instanceOf_duckType_fallback strategy:', () => {
     // The emitted error contains a path that isn't stable across the CI/CI matrix. Needs to be processed.
     expect(result) {
       if (result.logs[0]) {
-        result.logs[0] = result.logs[0]!.replace(/(.*imported from).*(is not the.*)/, '$1 <dynamic_path> $2')
+        result.logs[0] = result.logs[0]!.replace(
+          /(.*imported from).*(is not the.*)/,
+          '$1 <dynamic_path> $2'
+        ).replace(ansiEscapeSequencePattern, '')
       }
       expect(result.logs).toMatchSnapshot(`logs`)
       expect(result.graphqlSchemaSDL).toMatchSnapshot(`graphqlSchemaSDL`)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,6 @@
       ".nexus-prisma": [".nexus-prisma"]
     }
   },
-  "include": ["src", "tests", "scripts"],
+  "include": ["src", "tests", "scripts", "utils"],
   "exclude": ["dist-*", "tests/e2e/fixtures", "docs"]
 }

--- a/utils/ansiEscapeSequencePattern.ts
+++ b/utils/ansiEscapeSequencePattern.ts
@@ -1,4 +1,5 @@
 /**
  * @see https://stackoverflow.com/questions/4842424/list-of-ansi-color-escape-sequences
  */
+// eslint-disable-next-line no-control-regex
 export const ansiEscapeSequencePattern = /\x1b\[[0-9]+m/g

--- a/utils/ansiEscapeSequencePattern.ts
+++ b/utils/ansiEscapeSequencePattern.ts
@@ -1,0 +1,4 @@
+/**
+ * @see https://stackoverflow.com/questions/4842424/list-of-ansi-color-escape-sequences
+ */
+export const ansiEscapeSequencePattern = /\x1b\[[0-9]+m/g


### PR DESCRIPTION
After looking into the issue, this is the only way to run the tests on our local.
In GitHub CI, the result comes without colors, but in our local, it's come with the colors, so I added a function to remove the colors only on our local because it does not exist already on the GitHub CI