### PR TITLE
fix: graphql peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   "prettier": "@prisma-labs/prettier-config",
   "peerDependencies": {
     "@prisma/client": "^4",
-    "graphql": "^15 | ^16",
+    "graphql": "^15.0.0 || ^16.0.0",
     "nexus": "^1.0.0",
     "ts-node": "^10.0.0"
   },


### PR DESCRIPTION
Using valid syntax for multiple peer versions.
