### PR TITLE
ci: ignore execa from renovate updates due exclusive esm support

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
   "assignees": ["rostislav-simonik"],
   "reviewers": ["rostislav-simonik"],
   "ignorePaths": [],
-  "ignoreDeps": ["read-pkg-up"],
+  "ignoreDeps": ["read-pkg-up", "execa"],
   "packageRules": [
     {
       "groupName": "Nextra packages",


### PR DESCRIPTION
execa@6.0.0+ is exclusively ESM module, we gonna ignore it from renovate maintenance until we will have better support for ESM modules
