### PR TITLE
chore: make docs dependencies as dev dependencies

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,24 +11,23 @@
     "format": "prettier --write .",
     "lint": "next lint"
   },
-  "dependencies": {
-    "@reach/skip-nav": "0.18.0",
-    "next": "13.1.1",
-    "nextra": "2.2.0",
-    "nextra-theme-docs": "2.2.0",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
-  },
+  "dependencies": {},
   "prettier": "@prisma-labs/prettier-config",
   "devDependencies": {
     "@prisma-labs/prettier-config": "0.1.0",
+    "@reach/skip-nav": "0.18.0",
     "@types/node": "18.11.18",
     "@types/react": "18.0.26",
     "autoprefixer": "10.4.13",
     "eslint": "8.31.0",
     "eslint-config-next": "13.1.1",
+    "next": "13.1.1",
+    "nextra": "2.2.0",
+    "nextra-theme-docs": "2.2.0",
     "postcss": "8.4.21",
     "prettier": "2.8.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "tailwindcss": "3.2.4",
     "typescript": "4.9.4"
   }


### PR DESCRIPTION
To ensure Renovate creating chore merges for docs dependencies.